### PR TITLE
設定値の見直し

### DIFF
--- a/src/main/resources/env.properties
+++ b/src/main/resources/env.properties
@@ -2,9 +2,6 @@
 ## 開発環境用設定ファイル
 ##
 
-# JNDIでDataSourceを取得する際のリソース名
-nablarch.connectionFactory.jndiResourceName=
-
 # JDBC接続ドライバクラス(DataSourceを直接使用する際の項目)
 # (開発時にJNDIを使用するのは煩雑であるため、開発環境のみDataSourceを直接使用する。)
 nablarch.db.jdbcDriver=org.h2.Driver

--- a/src/main/resources/web-component-configuration.xml
+++ b/src/main/resources/web-component-configuration.xml
@@ -19,7 +19,7 @@
 
   <!-- web固有設定の読み込み -->
   <!-- データベース設定 -->
-  <import file="nablarch/webui/db-for-webui.xml"/>
+  <import file="nablarch/core/db-base.xml"/>
   <import file="db.xml" />
 
   <!-- Interceptorの実行順定義 -->


### PR DESCRIPTION
直接データソースを使っているが、一旦JNDI用のコンポーネント定義を読み込んでから上書きする設定になっていたので、不要なJNDI用コンポーネント定義が読まれないように修正。合わせて空の設定値を削除。

READMEに記載の方法で動作確認済み。