### PR TITLE
Jettyで起動した際にJSTLのJARが重複する警告が出力されるので、Webアプリ側には含めないようにして警告を抑制

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,12 @@
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-maven-plugin</artifactId>
         <version>12.0.3</version>
+        <configuration>
+          <webApp>
+            <!-- Jettyに含まれるJSTLと重複するので、Webアプリに含まれるJSTLはJettyで起動する際には除外する -->
+            <webInfIncludeJarPattern><![CDATA[.*/[^/]+(?<!jakarta\.servlet\.jsp\.jstl-[^/]+)\.jar$]]></webInfIncludeJarPattern>
+          </webApp>
+        </configuration>
       </plugin>
       <!-- カバレッジ取得 -->
       <plugin>


### PR DESCRIPTION
Thymeleaf自体はJSP/JSTLを使用しないが、以下の依存関係のJSTL（実装）のJARが含まれており警告が出力されてしまうので除外設定を追加。

```xml
    <dependency>
      <groupId>com.nablarch.profile</groupId>
      <artifactId>nablarch-web</artifactId>
    </dependency>
```